### PR TITLE
Add Video support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3"       
+        "php": ">=7.1.3",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
+        "ext-curl": "*",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/LiveStream/LiveStream.php
+++ b/src/LiveStream/LiveStream.php
@@ -58,7 +58,7 @@ class LiveStream
     /**
      * Secure access token.
      *
-     * @var array
+     * @var string
      */
     private $token;
 
@@ -92,7 +92,7 @@ class LiveStream
         $this->clientId = $clientId;
         $this->scope = $scope;
 
-        if ($this->clientId  && $this->scope) {
+        if ($this->clientId !== null && $this->scope !== null) {
             $this->refreshToken();
         }
     }

--- a/src/LiveStream/LiveStream.php
+++ b/src/LiveStream/LiveStream.php
@@ -166,14 +166,56 @@ class LiveStream
     }
 
     /**
+     * Gets Events by type.
+     *
+     * @param string $type
+     *   Valid values: draft, past, private, or upcoming.
+     * @param int $accountId
+     * @param int $page
+     * @param int $maxItems
+     * @param string $order
+     *
+     * @return array
+     *
+     * @throws \LiveStream\Exceptions\LiveStreamException
+     */
+    protected function getEvents(
+        string $type,
+        int $accountId,
+        int $page,
+        int $maxItems,
+        string $order
+    ) {
+        $events = [];
+
+        $response = $this->request("accounts/{$accountId}/{$type}_events", 'get', null, [
+          'page'     => $page,
+          'maxItems' => $maxItems,
+          'order'    => $order
+        ]);
+
+        if ($response === null) return $events;
+
+        foreach (json_decode($response)->data as $event) {
+            $events[] = Event::fromObject($event);
+        }
+
+        return $events;
+    }
+
+    /**
      * Get Draft Events
      *
      * @param integer $accountId
      * @param integer $page
      * @param integer $maxItems
-     * @param string  $order
-     * 
+     * @param string $order
+     *
      * @return array
+     *
+     * @throws \LiveStream\Exceptions\LiveStreamException
+     *
+     * @see https://livestream.com/developers/docs/api/#get-draft-events
      */
     public function getDraftEvents(
         int $accountId,
@@ -181,21 +223,76 @@ class LiveStream
         int $maxItems = 10,
         string $order = 'desc'
     ): array {
-        $response = $this->request("accounts/$accountId/draft_events", 'get', null, [
-            'page'     => $page,
-            'maxItems' => $maxItems,
-            'order'    => $order
-        ]);
+        return $this->getEvents('draft', $accountId, $page, $maxItems, $order);
+    }
 
-        if ($response === null) return null;
+    /**
+     * Get Past Events
+     *
+     * @param integer $accountId
+     * @param integer $page
+     * @param integer $maxItems
+     * @param string $order
+     *
+     * @return array
+     *
+     * @throws \LiveStream\Exceptions\LiveStreamException
+     *
+     * @see https://livestream.com/developers/docs/api/#get-past-events
+     */
+    public function getPastEvents(
+        int $accountId,
+        int $page = 1,
+        int $maxItems = 10,
+        string $order = 'desc'
+    ): array {
+        return $this->getEvents('past', $accountId, $page, $maxItems, $order);
+    }
 
-        $events = [];
+    /**
+     * Get Private Events
+     *
+     * @param integer $accountId
+     * @param integer $page
+     * @param integer $maxItems
+     * @param string $order
+     *
+     * @return array
+     *
+     * @throws \LiveStream\Exceptions\LiveStreamException
+     *
+     * @see https://livestream.com/developers/docs/api/#get-private-events
+     */
+    public function getPrivateEvents(
+        int $accountId,
+        int $page = 1,
+        int $maxItems = 10,
+        string $order = 'asc'
+    ): array {
+        return $this->getEvents('private', $accountId, $page, $maxItems, $order);
+    }
 
-        foreach (json_decode($response)->data as $event) {
-            $events[] = Event::fromObject($event);
-        }
-
-        return $events;
+    /**
+     * Get Upcoming Events
+     *
+     * @param integer $accountId
+     * @param integer $page
+     * @param integer $maxItems
+     * @param string $order
+     *
+     * @return array
+     *
+     * @throws \LiveStream\Exceptions\LiveStreamException
+     *
+     * @see https://livestream.com/developers/docs/api/#get-upcoming-events
+     */
+    public function geUpcomingEvents(
+        int $accountId,
+        int $page = 1,
+        int $maxItems = 10,
+        string $order = 'asc'
+    ): array {
+        return $this->getEvents('upcoming', $accountId, $page, $maxItems, $order);
     }
 
     /**

--- a/src/LiveStream/LiveStream.php
+++ b/src/LiveStream/LiveStream.php
@@ -428,6 +428,28 @@ class LiveStream
     }
 
     /**
+     * Gets URL of a Video's HLS stream (m3u8) file with access token.
+     *
+     * Requires a secure access token. Generates the URL using the "playback"
+     * scope.
+     *
+     * @param \LiveStream\Resources\Video $video
+     *
+     * @return string|null
+     */
+    public function getVideoHlsFileUrl(Video $video): ?string {
+        if (!$video->m3u8) return null;
+
+        $token = $this->generateToken('playback');
+        $query = [
+          'clientId' => $this->clientId,
+          'timestamp' => $token['timestamp'],
+          'token' => $token['token']
+        ];
+        return $video->m3u8 . '?' . http_build_query($query);
+    }
+
+    /**
      * Gets contents of a Video's HLS stream (m3u8) file.
      *
      * Requires a secure access token.
@@ -437,7 +459,7 @@ class LiveStream
      * @return string|null
      * @throws \LiveStream\Exceptions\LiveStreamException
      */
-    public function getVideoHlsFile(Video $video): ?string {
+    public function getVideoHlsFileContents(Video $video): ?string {
         if (!$video->m3u8) return null;
 
         $endpoint = substr($video->m3u8, strlen(self::BASE_URL));

--- a/src/LiveStream/LiveStream.php
+++ b/src/LiveStream/LiveStream.php
@@ -12,6 +12,7 @@ use LiveStream\Interfaces\Resource;
 
 use LiveStream\Exceptions\LiveStreamException;
 use LiveStream\Exceptions\InValidResourceException;
+use LiveStream\Resources\Video;
 
 class LiveStream
 {
@@ -336,6 +337,48 @@ class LiveStream
         if ($response === null) return null;
 
         return RTMPKey::fromObject(json_decode($response));
+    }
+
+    /**
+     * Gets current live Video for an Event, if one exists.
+     *
+     * @param int $accountId
+     * @param int $eventId
+     * @param ?int $offsetPostId
+     * @param ?int $older
+     * @param ?int $newer
+     *
+     * @return \LiveStream\Resources\Video|null
+     *
+     * @see https://livestream.com/developers/docs/api/#get-videos
+     *
+     * @throws \LiveStream\Exceptions\LiveStreamException
+     */
+    public function getLiveVideo(
+      int $accountId,
+      int $eventId,
+      ?int $offsetPostId = null,
+      ?int $older = null,
+      ?int $newer = null
+    ): ?Video {
+        $video = null;
+
+        $response = $this->request("accounts/$accountId/events/$eventId/videos", 'get', null, [
+          'offsetPostId' => $offsetPostId,
+          'older'        => $older,
+          'newer'        => $newer
+        ]);
+
+        if ($response === null) return null;
+
+        $response_data = json_decode($response);
+
+        if ($response_data->live) {
+            /** @var \LiveStream\Resources\Video $video */
+            $video = Video::fromObject($response_data->live);
+        }
+
+        return $video;
     }
 
     /**

--- a/src/LiveStream/LiveStream.php
+++ b/src/LiveStream/LiveStream.php
@@ -428,6 +428,23 @@ class LiveStream
     }
 
     /**
+     * Gets contents of a Video's HLS stream (m3u8) file.
+     *
+     * Requires a secure access token.
+     *
+     * @param \LiveStream\Resources\Video $video
+     *
+     * @return string|null
+     * @throws \LiveStream\Exceptions\LiveStreamException
+     */
+    public function getVideoHlsFile(Video $video): ?string {
+        if (!$video->m3u8) return null;
+
+        $endpoint = substr($video->m3u8, strlen(self::BASE_URL));
+        return $this->request($endpoint);
+    }
+
+    /**
      * Refreshes a secure access token if invalid (5 minute life time).
      *
      * @see https://github.com/Livestream/livestream-api-samples/tree/master/php/secure-token-auth-sample

--- a/src/LiveStream/Resources/Video.php
+++ b/src/LiveStream/Resources/Video.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LiveStream\Resources;
+
+/**
+ * Video Object
+ * 
+ * @property int $id The integer representation of the unique identifier for this video post.
+ * @property bool $draft This indicates whether or not the post is published.
+ * @property int $views The number of times this video post was viewed.
+ * @property object $likes An object containing a single property, total, which indicates the number of accounts who like this video post.
+ * @property object $comments An object containing a single property, total, which indicates the number of accounts who have commented on this video post.
+ * @property string $caption The user-defined title of the video post as a UTF-8 string.
+ * @property string $description The user-defined detailed description of the video post as a UTF-8 string.
+ * @property int $duration The duration of video in milliseconds.
+ * @property int $eventId The unique ID of the event where this video post has been posted.
+ * @property string $createdAt The creation date and time for the post as a string in ISO 8601 date time format.
+ * @property ?string $publishAt Videos are published instantly by default unless draft is set to true. To publish an event in the future, set the date and time using ISO8601 date time format.
+ * @property string $thumbnailUrl The full URL of the video thumbnail.
+ * @property string $thumbnailUrlSmall The full URL of the small thumbnail of the video (150px x 84px).
+ * @property string $m3u8 The m3u8 url of the live/VOD HLS stream (requires secure token authentication).
+ * @property array $tags Tags given for the video post in an array.
+ */
+class Video extends Resource
+{
+
+}


### PR DESCRIPTION
The primary focus of this branch is to add support for getting an HLS file for a live video stream. This required secure access tokens, so this PR does quite a few things:

1. Adds a `Video` resource type.
2. Adds optional constructor parameters for secure access token requirements (does not affect creating a client with just an API key).
3. Adds support for getting all event types (past, upcoming, draft, and private).
4. Adds support for getting the contents or URL of an HLS stream file for a provided `Video` instance.

Here is an example script I was testing with that gets all Accounts, gets each Account's private Videos, and prints out each Video's caption, HLS file URL, and HLS file contents:

```php
<?php

require_once "vendor/autoload.php";

use LiveStream\LiveStream;

$api_secret = '[SECRET]';
$client_id = [ID];
$scope = '[SCOPE]';

$client = new LiveStream($api_secret, $client_id, $scope);

foreach ($client->getAccounts() as $account) {
    print "{$account->id}\n\n";
    foreach ($client->getPrivateEvents($account->id) as $event) {
        $video = $client->getLiveVideo($account->id, $event->id);
        if ($video) {
            print "{$video->caption}: {$video->m3u8}\n";
            print "{$client->getVideoHlsFileUrl($video)}\n";
            print "{$client->getVideoHlsFileContents($video)}\n";
        }
    }
}
?>